### PR TITLE
Depends on `zip-zip`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ Echoe.new('smartcard') do |p|
   p.url = 'http://www.costan.us/smartcard'
   p.dependencies = ['ffi >=1.2.0',
                     'rubyzip >=0.9.9',
+                    'zip-zip >=0.3',
                     'zerg_support >=0.1.6']
   p.development_dependencies = ['echoe >=4.6.3',
                                 'flexmock >=1.2.0']


### PR DESCRIPTION
There is a [`require 'zip/zip'` in `Smartcard::Gp::CapLoader`](https://github.com/jamesottaway/smartcard/blob/master/lib/smartcard/gp/cap_loader.rb#L8).

Without an explicit dependency on the `zip-zip` gem, projects like mine which use Bundler will not make that gem available to `smartcard`, causing a runtime error.
